### PR TITLE
watergimbal with no need for adjacent plant sourcing

### DIFF
--- a/jedcore config.yml
+++ b/jedcore config.yml
@@ -833,7 +833,7 @@ Abilities:
         Speed: 2
         AnimationSpeed: 3
         PlantSource: true
-        RequireAdjacentPlants: true
+        RequireAdjacentPlants: false
         BottleSource: false
         AbilityCollisionRadius: 1.6
         EntityCollisionRadius: 1.6


### PR DESCRIPTION
i think watergimbal should be able to plant source from any source regardless of the need to hone in on adjacent plants because well, its pretty hard to focus onto any adjacent plants mid battle
another reason would be that itll make waterbending on land more versatile